### PR TITLE
Fix NDI6 packaging mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,4 +85,19 @@ configure_file(
 )
 
 target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib/ndi)
-set_target_properties_plugin(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})
+
+if(OS_MACOS AND COMMAND set_target_properties_obs)
+  if(TARGET plugin-support)
+    target_link_libraries(${PROJECT_NAME} PRIVATE plugin-support)
+  endif()
+
+  set_target_properties_obs(
+    ${PROJECT_NAME}
+    PROPERTIES
+      FOLDER plugins/obs-ndi
+      PREFIX ""
+      OUTPUT_NAME ${_name}
+  )
+else()
+  set_target_properties_plugin(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})
+endif()


### PR DESCRIPTION
### Description
Fixes macOS packaging for the `obs-ndi` plugin by integrating it with OBS's native macOS plugin target setup.

### Motivation and Context

The [NDI 6 runtime-loading fix](https://github.com/streamlabs/obs-ndi/pull/26) was working, but packaged macOS builds could still omit `obs-ndi.plugin`. The generic external-plugin setup built the bundle without registering it with OBS's macOS application packaging process.

Consequently, downstream `obs-studio-node` packages could be released without the NDI plugin, making NDI sources unavailable regardless of whether NDI Tools 6 was installed.

This change ensures the plugin is included in the OBS application bundle and subsequently copied into OSN/Desktop packages.